### PR TITLE
Enhance form components

### DIFF
--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -176,7 +176,7 @@ export function Textarea(props: RenderableProps<ITextareaProps>) {
     [`is-${props.size}`]: !!props.size
   });
   return (
-    <textarea class={classes} {...props as any}>
+    <textarea class={classes} {...(props as any)}>
       {props.children}
     </textarea>
   );
@@ -215,17 +215,28 @@ export function Select(props: RenderableProps<ISelectProps>) {
 }
 
 export interface ICheckboxProps {
-  value?: boolean;
+  checked?: boolean;
   disabled?: boolean;
   onChanged?: (ev: Event) => void;
   id?: string;
   name?: string;
+  onFocus?: (ev: Event) => void;
+  onBlur?: (ev: Event) => void;
 }
 
 export function Checkbox(props: RenderableProps<ICheckboxProps>) {
   return (
     <label class="checkbox">
-      <input type="checkbox" disabled={props.disabled} id={props.id} name={props.name} />
+      <input
+        type="checkbox"
+        checked={props.checked}
+        disabled={props.disabled}
+        id={props.id}
+        name={props.name}
+        onChange={props.onChanged}
+        onFocus={props.onFocus}
+        onBlur={props.onBlur}
+      />
       {props.children}
     </label>
   );

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -192,6 +192,11 @@ export interface ISelectProps {
   size?: "small" | "medium" | "large";
   id?: string;
   name?: string;
+  disabled?: boolean;
+  value: string;
+  onChange: (ev: Event) => void;
+  onFocus: (ev: Event) => void;
+  onBlur: (ev: Event) => void;
 }
 
 export function Select(props: RenderableProps<ISelectProps>) {
@@ -205,9 +210,19 @@ export function Select(props: RenderableProps<ISelectProps>) {
   });
   return (
     <div class={classes}>
-      <select id={props.id} name={props.id}>
+      <select
+        id={props.id}
+        name={props.id}
+        value={props.value}
+        onChange={props.onChange}
+        onFocus={props.onFocus}
+        onBlur={props.onBlur}
+        disabled={props.disabled}
+      >
         {props.options.map(el => (
-          <option>{el}</option>
+          <option key={el} value={el}>
+            {el}
+          </option>
         ))}
       </select>
     </div>

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -277,11 +277,24 @@ export function Checkbox(props: RenderableProps<ICheckboxProps>) {
 
 export interface IRadioButtonProps {
   name: string;
+  id?: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (ev: Event) => void;
 }
+
 export function RadioButton(props: RenderableProps<IRadioButtonProps>) {
   return (
     <label>
-      <input type="radio" name={props.name} /> {props.children}
+      <input
+        type="radio"
+        id={props.id}
+        name={props.name}
+        checked={props.checked}
+        disabled={props.disabled}
+        onChange={props.onChange}
+      />{" "}
+      {props.children}
     </label>
   );
 }

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -1,6 +1,9 @@
 import classnames from "classnames";
 import { Component, ComponentChild, JSX, h, RenderableProps } from "preact";
 
+const NODE_ENV = process.env.NODE_ENV;
+const IS_DEVELOPMENT = NODE_ENV === "development";
+
 const GROUP_ALIGNMENTS = {
   left: "is-grouped",
   center: "is-grouped-centered",
@@ -248,9 +251,11 @@ export function Select(props: RenderableProps<ISelectProps>) {
 }
 
 export interface ICheckboxProps {
+  value?: boolean;
   checked?: boolean;
   disabled?: boolean;
   onChanged?: (ev: Event) => void;
+  onChange?: (ev: Event) => void;
   id?: string;
   name?: string;
   onFocus?: (ev: Event) => void;
@@ -258,15 +263,25 @@ export interface ICheckboxProps {
 }
 
 export function Checkbox(props: RenderableProps<ICheckboxProps>) {
+  if (IS_DEVELOPMENT && props.value) {
+    console.warn("Checkbox.value will be deprecated in a future release. Please use Checkbox.checked instead.");
+  }
+  if (IS_DEVELOPMENT && props.onChanged) {
+    console.warn("Checkbox.onChanged will be deprecated in a future release. Please use Checkbox.onChange instead.");
+  }
+
+  const changeEvent = props.onChanged || props.onChange;
+  const checked = props.value || props.checked;
+
   return (
     <label class="checkbox">
       <input
         type="checkbox"
-        checked={props.checked}
+        checked={checked}
         disabled={props.disabled}
         id={props.id}
         name={props.name}
-        onChange={props.onChanged}
+        onChange={changeEvent}
         onFocus={props.onFocus}
         onBlur={props.onBlur}
       />

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -270,8 +270,8 @@ export function Checkbox(props: RenderableProps<ICheckboxProps>) {
     console.warn("Checkbox.onChanged will be deprecated in a future release. Please use Checkbox.onChange instead.");
   }
 
-  const changeEvent = props.onChanged || props.onChange;
-  const checked = props.value || props.checked;
+  const changeEvent = props.onChange || props.onChanged;
+  const checked = props.checked || props.value;
 
   return (
     <label class="checkbox">
@@ -333,6 +333,10 @@ export interface IFileInputProps {
 }
 
 export function FileInput(props: RenderableProps<IFileInputProps>) {
+  if (IS_DEVELOPMENT && props.filename) {
+    console.warn("FileInput.filename will be deprecated in a future release. Please use FileInput.filenames instead.");
+  }
+
   const hasFiles = !!props.filename || !!props.filenames;
   let label: preact.JSX.Element;
   let icon: preact.JSX.Element;
@@ -356,17 +360,12 @@ export function FileInput(props: RenderableProps<IFileInputProps>) {
       </span>
     );
   }
-  if (props.filename) {
-    filename = <span class="file-name">{props.filename}</span>;
-  }
-  if (props.filenames && props.filenames.length > 0) {
+  if ((props.filenames && props.filenames.length === 1) || props.filename) {
+    const copy = (props.filenames && props.filenames[0]) || props.filename;
+    filename = <span class="file-name">{copy}</span>;
+  } else if (props.filenames && props.filenames.length > 1) {
     const count = props.filenames.length;
-    const copy = count === 1 ? "File" : "Files";
-    filename = (
-      <span class="file-name">
-        {count} {copy}
-      </span>
-    );
+    filename = <span class="file-name">{count} Files</span>;
   }
   return (
     <div class={classes}>

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -167,6 +167,12 @@ export interface ITextareaProps {
   readOnly?: boolean;
   disabled?: boolean;
   fixed?: boolean;
+  value: string;
+  id?: string;
+  name?: string;
+  onInput: (ev: Event) => void;
+  onBlur?: (ev: Event) => void;
+  onFocus?: (ev: Event) => void;
 }
 
 export function Textarea(props: RenderableProps<ITextareaProps>) {
@@ -176,7 +182,19 @@ export function Textarea(props: RenderableProps<ITextareaProps>) {
     [`is-${props.size}`]: !!props.size
   });
   return (
-    <textarea class={classes} {...(props as any)}>
+    <textarea
+      class={classes}
+      disabled={props.disabled}
+      onBlur={props.onBlur}
+      onFocus={props.onFocus}
+      onInput={props.onInput}
+      placeholder={props.placeholder}
+      readOnly={props.readOnly}
+      id={props.id}
+      name={props.name}
+      value={props.value}
+      {...(props as any)}
+    >
       {props.children}
     </textarea>
   );

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -213,8 +213,8 @@ export interface ISelectProps {
   disabled?: boolean;
   value: string;
   onChange: (ev: Event) => void;
-  onFocus: (ev: Event) => void;
-  onBlur: (ev: Event) => void;
+  onFocus?: (ev: Event) => void;
+  onBlur?: (ev: Event) => void;
 }
 
 export function Select(props: RenderableProps<ISelectProps>) {

--- a/src/forms/index.tsx
+++ b/src/forms/index.tsx
@@ -309,11 +309,16 @@ export interface IFileInputProps {
   size?: "small" | "medium" | "large";
   align?: keyof typeof ALIGNMENTS;
   filename?: string;
+  filenames?: string[];
   name?: string;
   id?: string;
+  multiple?: boolean;
+  disabled?: boolean;
+  onChange: (ev: Event) => void;
 }
 
 export function FileInput(props: RenderableProps<IFileInputProps>) {
+  const hasFiles = !!props.filename || !!props.filenames;
   let label: preact.JSX.Element;
   let icon: preact.JSX.Element;
   let filename: preact.JSX.Element;
@@ -321,7 +326,7 @@ export function FileInput(props: RenderableProps<IFileInputProps>) {
     "is-fullwidth": !!props.fullWidth,
     "is-right": !!props.right,
     "is-boxed": !!props.boxed,
-    "has-name": !!props.filename,
+    "has-name": hasFiles,
     [`is-${props.color}`]: !!props.color,
     [`is-${props.size}`]: !!props.size,
     [ALIGNMENTS[props.align]]: !!props.align
@@ -339,14 +344,32 @@ export function FileInput(props: RenderableProps<IFileInputProps>) {
   if (props.filename) {
     filename = <span class="file-name">{props.filename}</span>;
   }
+  if (props.filenames && props.filenames.length > 0) {
+    const count = props.filenames.length;
+    const copy = count === 1 ? "File" : "Files";
+    filename = (
+      <span class="file-name">
+        {count} {copy}
+      </span>
+    );
+  }
   return (
     <div class={classes}>
       <label class="file-label">
-        <input class="file-input" type="file" id={props.id} name={props.name} />
+        <input
+          class="file-input"
+          type="file"
+          id={props.id}
+          name={props.name}
+          multiple={props.multiple}
+          disabled={props.disabled}
+          onChange={props.onChange}
+        />
         <span class="file-cta">
           {icon}
           {label}
         </span>
+        {filename}
       </label>
     </div>
   );

--- a/stories/forms/checkbox.tsx
+++ b/stories/forms/checkbox.tsx
@@ -1,0 +1,25 @@
+import { action } from "@storybook/addon-actions";
+import { boolean, text, withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/preact";
+import { h } from "preact";
+
+import { Control, Field, Checkbox } from "../../src/forms";
+
+storiesOf("Forms", module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => <form onSubmit={ev => ev.preventDefault()}>{story()}</form>)
+  .add("Checkbox", () => (
+    <Field label={text("label", "Field Label")} help={text("help", "Field help text")}>
+      <Control loading={boolean("loading", false)}>
+        <Checkbox
+          disabled={boolean("disabled", false)}
+          onChanged={action("onChanged")}
+          onFocus={action("onFocus")}
+          onBlur={action("onBlur")}
+          checked={boolean("checked", true)}
+        >
+          {text("children", "Checkbox children")}
+        </Checkbox>
+      </Control>
+    </Field>
+  ));

--- a/stories/forms/checkbox.tsx
+++ b/stories/forms/checkbox.tsx
@@ -14,8 +14,10 @@ storiesOf("Forms", module)
         <Checkbox
           disabled={boolean("disabled", false)}
           onChanged={action("onChanged")}
+          onChange={action("onChange")}
           onFocus={action("onFocus")}
           onBlur={action("onBlur")}
+          value={boolean("value", false)}
           checked={boolean("checked", true)}
         >
           {text("children", "Checkbox children")}

--- a/stories/forms/fileinput.tsx
+++ b/stories/forms/fileinput.tsx
@@ -1,0 +1,59 @@
+import { boolean, select, text, withKnobs, array } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
+import { storiesOf } from "@storybook/preact";
+import { h } from "preact";
+
+import { Control, Field, FileInput } from "../../src/forms";
+
+const COLORS = {
+  None: "",
+  Primary: "primary",
+  Light: "light",
+  Dark: "dark",
+  Info: "info",
+  Warning: "warning",
+  Danger: "danger"
+};
+
+const SIZES = {
+  Default: null,
+  Small: "small",
+  Medium: "medium",
+  Large: "large"
+};
+
+storiesOf("Forms/File Input", module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => <form onSubmit={ev => ev.preventDefault()}>{story()}</form>)
+  .add("Single", () => (
+    <Field label={text("Field Label", "Field Label")} help={text("Field Help", "Field help text")}>
+      <Control loading={boolean("Loading", false)}>
+        <FileInput
+          label={text("File Input Label", "File Input Label")}
+          icon={text("Icon", "fas fa-upload")}
+          filename={text("File Name", "Expenses.xlsx")}
+          color={select("Color", COLORS, "None")}
+          size={select("Size", SIZES, "Default")}
+          multiple={boolean("Multiple", false)}
+          disabled={boolean("Disabled", false)}
+          onChange={action("onChange")}
+        />
+      </Control>
+    </Field>
+  ))
+  .add("Multiple", () => (
+    <Field label={text("Field Label", "Field Label")} help={text("Field Help", "Field help text")}>
+      <Control loading={boolean("Loading", false)}>
+        <FileInput
+          label={text("File Input Label", "File Input Label")}
+          icon={text("Icon", "fas fa-upload")}
+          filenames={array("File names", ["A.xlsx", "B.pdf"])}
+          color={select("Color", COLORS, "None")}
+          size={select("Size", SIZES, "Default")}
+          multiple={true}
+          disabled={boolean("Disabled", false)}
+          onChange={action("onChange")}
+        />
+      </Control>
+    </Field>
+  ));

--- a/stories/forms/radiobutton.tsx
+++ b/stories/forms/radiobutton.tsx
@@ -1,0 +1,24 @@
+import { action } from "@storybook/addon-actions";
+import { boolean, text, withKnobs } from "@storybook/addon-knobs";
+import { storiesOf } from "@storybook/preact";
+import { h } from "preact";
+
+import { Control, Field, RadioButton } from "../../src/forms";
+
+storiesOf("Forms", module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => <form onSubmit={ev => ev.preventDefault()}>{story()}</form>)
+  .add("Radio Button", () => (
+    <Field label={text("label", "Field Label")} help={text("help", "Field help text")}>
+      <Control>
+        <RadioButton
+          name={text("Name", "MyRadio")}
+          disabled={boolean("disabled", false)}
+          checked={boolean("Checked", false)}
+          onChange={action("onChange")}
+        >
+          {text("children", "Radio Button children")}
+        </RadioButton>
+      </Control>
+    </Field>
+  ));

--- a/stories/forms/select.tsx
+++ b/stories/forms/select.tsx
@@ -1,10 +1,12 @@
 import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/preact";
 import { h } from "preact";
 
 import { Control, Field, Select } from "../../src/forms";
 
 const OPTIONS = [
+  "",
   "Alabama",
   "Alaska",
   "Arizona",
@@ -71,7 +73,7 @@ storiesOf("Forms", module)
   .addDecorator(withKnobs)
   .addDecorator(story => <form onSubmit={ev => ev.preventDefault()}>{story()}</form>)
   .add("Select", () => (
-    <Field>
+    <Field label={text("label", "Field Label")} help={text("help", "Field help text")}>
       <Control iconsLeft={text("Icon left", "fas fa-globe")} iconsRight={text("Icon right", "")}>
         <Select
           options={OPTIONS}
@@ -80,6 +82,11 @@ storiesOf("Forms", module)
           rounded={boolean("Rounded", false)}
           fullWidth={boolean("Full width", false)}
           loading={boolean("Loading", false)}
+          disabled={boolean("Disabled", false)}
+          value={text("Value", "")}
+          onChange={action("onChange")}
+          onFocus={action("onFocus")}
+          onBlur={action("onBlur")}
         />
       </Control>
     </Field>

--- a/stories/forms/textarea.tsx
+++ b/stories/forms/textarea.tsx
@@ -1,4 +1,5 @@
 import { boolean, select, text, withKnobs } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/preact";
 import { h } from "preact";
 
@@ -25,7 +26,7 @@ storiesOf("Forms", module)
   .addDecorator(withKnobs)
   .addDecorator(story => <form onSubmit={ev => ev.preventDefault()}>{story()}</form>)
   .add("Textarea", () => (
-    <Field label="Textarea">
+    <Field label={text("Field Label", "Field Label")} help={text("Field Help", "Field help text")}>
       <Control loading={boolean("Loading", false)}>
         <Textarea
           placeholder="Lorem ipsum etc."
@@ -34,6 +35,10 @@ storiesOf("Forms", module)
           disabled={boolean("Disabled", false)}
           readOnly={boolean("Read-only", false)}
           fixed={boolean("Fixed", false)}
+          value={text("Value", "")}
+          onInput={action("onInput")}
+          onBlur={action("onBlur")}
+          onFocus={action("onFocus")}
         />
       </Control>
     </Field>


### PR DESCRIPTION
The provided Form components were missing a few key props that made them not work with forms 😭 This PR adds those props to the existing Form components:

* `Checkbox`
* `Select`
* `Textarea`
* `RadioButton`
* `FileInput`

A new Story was created, or the existing one was updated to reflect and demo these changes.

I also made an enhancement to `FileInput`; you can see the file name now! 

<img width="347" alt="image" src="https://user-images.githubusercontent.com/43730825/73597513-5cec8400-44f2-11ea-9bdb-9980226364f8.png">

It supports multiple file names too:

<img width="299" alt="image" src="https://user-images.githubusercontent.com/43730825/73597509-51995880-44f2-11ea-824b-f8c34b469337.png">

This PR shouldn't introduce any breaking API changes, but there is one area where I think we should consider a breaking change. I'll add that as an inline comment shortly.